### PR TITLE
feat(domain): Implement age increment and natural death logic

### DIFF
--- a/src/main/java/com/example/chimpanzee_simulation/domain/model/Chimpanzee.java
+++ b/src/main/java/com/example/chimpanzee_simulation/domain/model/Chimpanzee.java
@@ -23,8 +23,9 @@ public class Chimpanzee {
     private boolean alive;              // 살아있는지
     private DeathReason deathReason;    // enum { STARVATION, DISEASE, PREDATOR, OLD_AGE, OTHER, NONE }
     private AgeCategory ageCategory;    // enum { INFANT, JUVENILE, ADOLESCENT, YOUNG_ADULT, ADULT, ELDER}
+    private int birthTurn;
 
-    private Chimpanzee(Long id, int age, Sex sex, int health, int strength, int agility, double reproductionRate, int longevity, boolean alpha, boolean alive, DeathReason deathReason, AgeCategory ageCategory) {
+    private Chimpanzee(Long id, int age, Sex sex, int health, int strength, int agility, double reproductionRate, int longevity, boolean alpha, boolean alive, DeathReason deathReason, AgeCategory ageCategory, int birthTurn) {
         this.id = id;
         this.age = age;
         this.sex = sex;
@@ -37,10 +38,11 @@ public class Chimpanzee {
         this.alive = alive;
         this.deathReason = deathReason;
         this.ageCategory = ageCategory;
+        this.birthTurn = birthTurn;
     }
 
     // 초기 랜덤 객체 생성 전용
-    public static Chimpanzee randomInitial(Long id, Random random) {
+    public static Chimpanzee randomInitial(Long id, Random random, int currentTurn) {
         int age = generateInitialAge(random);
         AgeCategory ageCategory = resolveAgeCategory(age);
 
@@ -65,7 +67,8 @@ public class Chimpanzee {
                 false,
                 true,
                 DeathReason.NONE,
-                ageCategory
+                ageCategory,
+                currentTurn
         );
     }
 
@@ -115,6 +118,39 @@ public class Chimpanzee {
         if (age <= 20) return AgeCategory.YOUNG_ADULT;
         if (age <= 35) return AgeCategory.ADULT;
         return AgeCategory.ELDER;
+    }
+
+    // 나이 증가 체크
+    public boolean incrementAgeIfNeeded(int currentTurn) {
+        int diff = currentTurn - this.birthTurn;
+
+        if (diff <= 0) return false;
+
+        if (diff % 4 == 0) {
+            this.age += 1;
+            this.ageCategory = resolveAgeCategory(this.age);
+            return true;
+        }
+        return false;
+    }
+
+    // 자연사 판정
+    public boolean checkNaturalDeath(int currentTurn, Random random) {
+        if (this.age < this.longevity) {
+            return false; // 자연사 없음
+        }
+
+        double base = 0.1 * (this.age - this.longevity + 1);
+        if (base > 0.9) base = 0.9;
+
+        double r = random.nextDouble();
+
+        if (r < base) {
+            this.alive = false;
+            this.deathReason = DeathReason.OLD_AGE;
+            return true;
+        }
+        return false;
     }
 
     // 테스트용 getter

--- a/src/main/java/com/example/chimpanzee_simulation/service/SimulationInitializerImpl.java
+++ b/src/main/java/com/example/chimpanzee_simulation/service/SimulationInitializerImpl.java
@@ -18,7 +18,7 @@ public class SimulationInitializerImpl implements SimulationInitializer {
 
         List<Chimpanzee> chimpanzees = new ArrayList<>();
         for (int i =0; i < DEFAULT_INITIAL_POPULATION; i++) {
-            chimpanzees.add(Chimpanzee.randomInitial((long) i+1, random));
+            chimpanzees.add(Chimpanzee.randomInitial((long) i+1, random,0));
         }
 
         Environment environment = Environment.randomInitial(DEFAULT_INITIAL_POPULATION, random);


### PR DESCRIPTION
## 🚀 관련 이슈

Close #10 

## 📑 PR 설명

## ✏️ 작업 내용
챔핀지 나이 증가 로직과 기대 수명을 넘었을 때 사망 확률에 따라 사망/생존 판별 로직 개발
## ✅ 체크리스트

- [x] Chimpanzee 객체에 birthTurn 필드 추가 (또는 기존 필드 재활용)
- [x] 생성 시 birthTurn = state.getTurn() 저장
- [x] 개체별로 (turn - birthTurn) % 4 == 0 조건 계산
- [x] 조건 충족 시 age += 1
- [x] 기대 수명 초과 시 자연사 확률 계산 로직 적용
- [x] 자연사 시 SimulationState에서 개체 상태 변경 or 제거 처리

## 📎 추가 정보

## 💬 리뷰 포인트