### PR TITLE
fix(reproduction): Prevent duplicate offspring IDs by using state.all…

### DIFF
--- a/src/main/java/com/example/chimpanzee_simulation/domain/model/SimulationState.java
+++ b/src/main/java/com/example/chimpanzee_simulation/domain/model/SimulationState.java
@@ -1,5 +1,6 @@
 package com.example.chimpanzee_simulation.domain.model;
 
+import java.util.Comparator;
 import java.util.List;
 
 public class SimulationState {
@@ -7,7 +8,7 @@ public class SimulationState {
     private int turnNumber;                     // 현재 턴 번호
     private List<Chimpanzee> chimpanzees;
     private Environment environment;
-
+    private long nextChimpId;
     private Long randomSeed;  // 재현성을 위해 필요하면 사용
 
     public SimulationState(int turnNumber, List<Chimpanzee> chimpanzees, Environment environment, long randomSeed) {
@@ -15,6 +16,16 @@ public class SimulationState {
         this.chimpanzees = chimpanzees;
         this.environment = environment;
         this.randomSeed = randomSeed;
+        this.nextChimpId = chimpanzees.stream()
+                .map(Chimpanzee::getId)
+                .filter(id -> id != null)
+                .max(Comparator.naturalOrder())
+                .map(max-> max+1)
+                .orElse(1L);
+    }
+
+    public long allocateChimpId() {
+        return nextChimpId++;
     }
 
     // 테스트용 getter

--- a/src/main/java/com/example/chimpanzee_simulation/service/ReproductionServiceImpl.java
+++ b/src/main/java/com/example/chimpanzee_simulation/service/ReproductionServiceImpl.java
@@ -54,7 +54,7 @@ public class ReproductionServiceImpl implements ReproductionService {
             }
 
             Chimpanzee father = fatherOpt.get();
-            Long childId = generateNewId(state);
+            Long childId = state.allocateChimpId();
 
             Chimpanzee child = Chimpanzee.createOffspring(
                     childId,
@@ -122,14 +122,6 @@ public class ReproductionServiceImpl implements ReproductionService {
                     + ", 암컷: 개체" + female.getId()
                     + ", 성공확률:" + String.format("%.0f%%", prob * 100));
         }
-    }
-
-    private Long generateNewId(SimulationState state) {
-        return state.chimpanzees().stream()
-                .map(Chimpanzee::getId)
-                .filter(Objects::nonNull)
-                .max(Long::compareTo)
-                .orElse(0L) + 1;
     }
 
     private Optional<Chimpanzee> findById(SimulationState state, Long id) {


### PR DESCRIPTION

## 🚀 관련 이슈

Close #30 

## 📑 PR 설명
기존 새로운 침팬지 출산 시 id 값을 현재 턴 + 1 에서 
침팬지들의 가장 큰 id 값에 + 1 하는 로직으로 변경
## ✏️ 작업 내용

## ✅ 체크리스트

- [x] SimulationState에 nextChimpId 필드 추가
- [x] nextChimpId를 List<Chimpanzee> 중에 가장 큰 id 값 + 1로 초기화
- [x] allocateChimpId()로 새로 출산한 침팬지의 id값 가져옴

## 📎 추가 정보

## 💬 리뷰 포인트