### PR TITLE
Fix/33 alpha challenge

### DIFF
--- a/src/main/java/com/example/chimpanzee_simulation/service/AlphaResolutionServiceImpl.java
+++ b/src/main/java/com/example/chimpanzee_simulation/service/AlphaResolutionServiceImpl.java
@@ -15,7 +15,7 @@ import java.util.Random;
 public class AlphaResolutionServiceImpl implements AlphaResolutionService {
 
     // 알파 도전 이벤트 발생 확률 (30%)
-    private static final double CHALLENGE_PROBABILITY = 0.3;
+    private static final double CHALLENGE_PROBABILITY = 0.4;
 
     @Override
     public void resolveAlpha(SimulationState state, TurnLog log) {


### PR DESCRIPTION
## 🚀 관련 이슈

Close #33 

## 📑 PR 설명

 우두머리(알파) 도전 로직이 실제 시뮬레이션에서 거의 발생하지 않는 문제를 해결하고,
 알파가 싸움과 노화, 환경에 의해 점진적으로 약해지며 도전/교체가 자연스럽게 일어나도록 밸런스를 조정했습니다.

## ✏️ 작업 내용

 - 랜덤 사용 버그 수정
 - 결투 피로도 반영(승자 피해 추가)
 - 알파 약화 조건 완화
 - 도전 발생 확률 상향
 - 약해진 알파에 대해 도전이 실제로 발생하는 빈도를 현실적인 수준으로 상향
 - challenger 후보 조건 완화

## ✅ 체크리스트

- [x] 로컬에서 정상 동작 확인

## 📎 추가 정보

## 💬 리뷰 포인트