### PR TITLE
Refactor/36 age based stat balance

### DIFF
--- a/src/main/java/com/example/chimpanzee_simulation/domain/model/Chimpanzee.java
+++ b/src/main/java/com/example/chimpanzee_simulation/domain/model/Chimpanzee.java
@@ -133,6 +133,101 @@ public class Chimpanzee {
         return AgeCategory.ELDER;
     }
 
+    /**
+     * 연령대별 능력치 성장/하락 곡선에서
+     * 한 살 증가 시 strength/agility에 적용할 변화량(Δ)를 샘플링한다.
+     *
+     * 이 메서드는 아직 어디에서도 호출되지 않으며,
+     * 이후 나이 증가 로직에 연결하여 실제 stat 성장/하락을 적용하는 데 사용된다.
+     */
+    private static int sampleGrowthDelta(AgeCategory ageCategory, Random random) {
+        double r = random.nextDouble();
+
+        switch (ageCategory) {
+            case INFANT:
+                // INFANT (0–4세)
+                // 20%: +1~+2, 60%: +3~+5, 20%: +6~+7
+                if (r < 0.2) {
+                    return randomBetween(random, 1, 2);
+                } else if (r < 0.8) {
+                    return randomBetween(random, 3, 5);
+                } else {
+                    return randomBetween(random, 6, 7);
+                }
+            case JUVENILE:
+                // JUVENILE (5–7세)
+                // 20%: +1~+2, 60%: +3~+4, 20%: +5~+6
+                if (r < 0.2) {
+                    return randomBetween(random, 1, 2);
+                } else if (r < 0.8) {
+                    return randomBetween(random, 3, 4);
+                } else {
+                    return randomBetween(random, 5, 6);
+                }
+            case ADOLESCENT:
+                // ADOLESCENT (8–12세)
+                // 30%: +1~+2, 50%: +3~+4, 20%: +5
+                if (r < 0.3) {
+                    return randomBetween(random, 1, 2);
+                } else if (r < 0.8) {
+                    return randomBetween(random, 3, 4);
+                } else {
+                    return 5;
+                }
+            case YOUNG_ADULT:
+                // YOUNG_ADULT (13–20세)
+                // 10%: +2~+3, 40%: 0~+1, 30%: -1~0, 20%: -2~-3
+                if (r < 0.1) {
+                    return randomBetween(random, 2, 3);
+                } else if (r < 0.5) {
+                    return randomBetween(random, 0, 1);
+                } else if (r < 0.8) {
+                    return randomBetween(random, -1, 0);
+                } else {
+                    return randomBetween(random, -3, -2);
+                }
+            case ADULT:
+                // ADULT (21–35세)
+                // 5%: +2, 25%: 0~+1, 40%: -1~-2, 30%: -3~-4
+                if (r < 0.05) {
+                    return 2;
+                } else if (r < 0.30) {
+                    return randomBetween(random, 0, 1);
+                } else if (r < 0.70) {
+                    return randomBetween(random, -2, -1);
+                } else {
+                    return randomBetween(random, -4, -3);
+                }
+            case ELDER:
+                // ELDER (36세 이상)
+                // 5%: +1, 20%: 0, 35%: -1~-2, 40%: -3~-5
+                if (r < 0.05) {
+                    return 1;
+                } else if (r < 0.25) {
+                    return 0;
+                } else if (r < 0.60) {
+                    return randomBetween(random, -2, -1);
+                } else {
+                    return randomBetween(random, -5, -3);
+                }
+            default:
+                // 방어적 기본값: 변화 없음
+                return 0;
+        }
+    }
+
+    private static int randomBetween(Random random, int minInclusive, int maxInclusive) {
+        if (minInclusive == maxInclusive) {
+            return minInclusive;
+        }
+        if (minInclusive > maxInclusive) {
+            int tmp = minInclusive;
+            minInclusive = maxInclusive;
+            maxInclusive = tmp;
+        }
+        return minInclusive + random.nextInt(maxInclusive - minInclusive + 1);
+    }
+
     // 나이 증가 체크
     public boolean incrementAgeIfNeeded(int currentTurn) {
         int diff = currentTurn - this.birthTurn;

--- a/src/main/java/com/example/chimpanzee_simulation/domain/model/Chimpanzee.java
+++ b/src/main/java/com/example/chimpanzee_simulation/domain/model/Chimpanzee.java
@@ -109,8 +109,8 @@ public class Chimpanzee {
     private static int generateInitialStrength(AgeCategory ageCategory, Random random) {
         switch (ageCategory) {
             case INFANT:
-                // 0~30
-                return randomBetween(random, 0, 25);
+                // 1~25
+                return randomBetween(random, 1, 25);
             case JUVENILE:
                 // 20~60
                 return randomBetween(random, 20, 60);
@@ -332,9 +332,9 @@ public class Chimpanzee {
 
         Sex newSex = generateInitialSex(random);
 
-        // 능력치 유전
-        int newStrength = inheritStat(father.strength, mother.strength, random);
-        int newAgility = inheritStat(father.agility, mother.agility, random);
+        // 힘/민첩은 아기 구간에서 시작하도록 낮은 범위에서 랜덤 부여
+        int newStrength = randomBetween(random, 1, 10);
+        int newAgility = randomBetween(random, 1, 10);
         int newLongevity = inheritStat(father.longevity, mother.longevity, random);
 
         // 새로운 침팬지의 체력은 100

--- a/src/main/java/com/example/chimpanzee_simulation/domain/model/Chimpanzee.java
+++ b/src/main/java/com/example/chimpanzee_simulation/domain/model/Chimpanzee.java
@@ -250,6 +250,16 @@ public class Chimpanzee {
         return minInclusive + random.nextInt(maxInclusive - minInclusive + 1);
     }
 
+    private static int clampStat(int value) {
+        if (value < 0) {
+            return 0;
+        }
+        if (value > 100) {
+            return 100;
+        }
+        return value;
+    }
+
     // 나이 증가 체크
     public boolean incrementAgeIfNeeded(int currentTurn) {
         int diff = currentTurn - this.birthTurn;
@@ -262,6 +272,20 @@ public class Chimpanzee {
             return true;
         }
         return false;
+    }
+
+    /**
+     * 현재 연령대에 따른 성장 곡선을 기반으로
+     * strength / agility를 한 살 증가분만큼 갱신한다.
+     */
+    public void applyAgeBasedGrowth(Random random) {
+        if (random == null) {
+            throw new IllegalArgumentException("random must not be null");
+        }
+
+        int delta = sampleGrowthDelta(this.ageCategory, random);
+        this.strength = clampStat(this.strength + delta);
+        this.agility = clampStat(this.agility + delta);
     }
 
     // 자연사 판정

--- a/src/main/java/com/example/chimpanzee_simulation/domain/model/Chimpanzee.java
+++ b/src/main/java/com/example/chimpanzee_simulation/domain/model/Chimpanzee.java
@@ -60,8 +60,8 @@ public class Chimpanzee {
         Sex sex = generateInitialSex(random);
 
         int health = generateInitialHealth(random);
-        int strength = generateInitialStrength(random);
-        int agility = generateInitialAgility(random);
+        int strength = generateInitialStrength(ageCategory, random);
+        int agility = generateInitialAgility(ageCategory, random);
 
         double reproductionRate = generateInitialReproductionRate(random);
         int longevity = generateInitialLongevity(random);
@@ -105,14 +105,36 @@ public class Chimpanzee {
         return 60 + random.nextInt(41);
     }
 
-    // 초기 힘 능력치를 생성한다. 0~100
-    private static int generateInitialStrength(Random random) {
-        return random.nextInt(101); // 0~100
+    // 연령대 기반 초기 힘 능력치를 생성한다.
+    private static int generateInitialStrength(AgeCategory ageCategory, Random random) {
+        switch (ageCategory) {
+            case INFANT:
+                // 0~30
+                return randomBetween(random, 0, 25);
+            case JUVENILE:
+                // 20~60
+                return randomBetween(random, 20, 60);
+            case ADOLESCENT:
+                // 40~80
+                return randomBetween(random, 40, 80);
+            case YOUNG_ADULT:
+                // 50~90
+                return randomBetween(random, 50, 90);
+            case ADULT:
+                // 60~95
+                return randomBetween(random, 60, 95);
+            case ELDER:
+                // 40~80
+                return randomBetween(random, 40, 80);
+            default:
+                return random.nextInt(101);
+        }
     }
 
-    // 초기 민첩 능력치를 생성한다. 0~100
-    private static int generateInitialAgility(Random random) {
-        return random.nextInt(101); // 0~100
+    // 연령대 기반 초기 민첩 능력치를 생성한다. (현재는 힘과 동일 범위)
+    private static int generateInitialAgility(AgeCategory ageCategory, Random random) {
+        // 힘과 동일한 분포를 사용하지만, 필요 시 다르게 조정 가능
+        return generateInitialStrength(ageCategory, random);
     }
 
     private static double generateInitialReproductionRate(Random random) {

--- a/src/main/java/com/example/chimpanzee_simulation/service/AgingServiceImpl.java
+++ b/src/main/java/com/example/chimpanzee_simulation/service/AgingServiceImpl.java
@@ -10,11 +10,10 @@ import java.util.Random;
 @Service
 public class AgingServiceImpl implements AgingService {
 
-    private final Random random = new Random();
-
     @Override
     public void applyAgingAndNaturalDeath(SimulationState state, TurnLog log) {
         int currentTurn = state.turn();
+        Random random = state.random();
 
         for (Chimpanzee chimp : state.chimpanzees()) {
             if (!chimp.isAlive()) {
@@ -24,7 +23,9 @@ public class AgingServiceImpl implements AgingService {
             // 나이 증가
             boolean aged = chimp.incrementAgeIfNeeded(currentTurn);
             if (aged) {
-                log.add("개체 #" + chimp.getId() + "의 나이가 1살 증가했습니다. -> 현재 나이: " + chimp.getAge());
+                // 연령 기반 스탯 성장/하락 적용
+                chimp.applyAgeBasedGrowth(random);
+                log.add("개체 #" + chimp.getId() + "의 나이가 1살 증가했습니다. (현재 나이: " + chimp.getAge() + ")");
             }
 
             // 자연사 판정
@@ -33,9 +34,9 @@ public class AgingServiceImpl implements AgingService {
                 continue;
             }
 
-            log.add("☠\uFE0F 개체 #" + chimp.getId() +
+            log.add("☠️ 개체 #" + chimp.getId() +
                     "가 노쇠로 자연사했습니다. (나이: " + chimp.getAge() +
-                    ", 기대수명:" + chimp.getLongevity() +
+                    ", 기대수명: " + chimp.getLongevity() +
                     ")");
         }
     }


### PR DESCRIPTION
## 🚀 관련 이슈

Close #36 

## 📑 PR 설명

침팬지 능력치(힘/민첩)를 나이/연령대에 따라 자연스럽게 성장·유지·하락하도록 하는 “연령 기반 성장 곡선”을 도입했습니다.
  초기 생성 개체와 이후 태어나는 아기 개체 모두 이 곡선을 따르도록 리팩터링하여,
  - 유아기 → 성장기 → 피크(청년기/성인 초반) → 노년기의 하락
  이라는 흐름이 시뮬레이션에 반영되도록 했습니다.

## ✏️ 작업 내용

  - 연령 기반 성장 곡선 헬퍼 추가 (`Chimpanzee`)
  - 초기 랜덤 생성(`randomInitial`) 능력치 범위 연령대 보정
  - 출생(offspring) 능력치 초기화 규칙 변경
  - 연령 증가 시 능력치 성장/하락 적용 (`applyAgeBasedGrowth`)

## ✅ 체크리스트

- [x] 로컬에서 정상 동작 확인
